### PR TITLE
Update createqsobjects.py

### DIFF
--- a/scripts/createqsobjects.py
+++ b/scripts/createqsobjects.py
@@ -13,7 +13,7 @@ with open(INPUTS_DIR) as file:
 
 aws_region = parameters['context']['region']
 aws_sl_region = parameters['context']['slregion']
-aws_account_id = parameters['context']['AWSAccountID']
+aws_account_id = parameters['context']['SecurityLakeAccountID']
 aws_principal_id = parameters['context']['QuickSightUserARN']
     
 def main(aws_region, aws_account_id, aws_principal_id):


### PR DESCRIPTION
Fixed the not found error when running deployment sh (qsdeploy.sh).  

aws_account_id = parameters['context']['AWSAccountID']

However, in cdk.json, it tries to load

    "SecurityLakeAccountID": 123456789012,


Making changes createpsobjects.py to make the deployment work
aws_account_id = parameters['context']['SecurityLakeAccountID']

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
